### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 texworks (0.6.5-2) UNRELEASED; urgency=medium
 
   * Use secure URI in Homepage field.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 03:08:53 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+texworks (0.6.5-2) UNRELEASED; urgency=medium
+
+  * Use secure URI in Homepage field.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 03:08:53 +0000
+
 texworks (0.6.5-1) unstable; urgency=medium
 
   * New upstream version 0.6.5

--- a/debian/changelog
+++ b/debian/changelog
@@ -3,6 +3,7 @@ texworks (0.6.5-2) UNRELEASED; urgency=medium
   * Use secure URI in Homepage field.
   * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
     Repository-Browse.
+  * Fix day-of-week for changelog entry 0.5~svn1026-1.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 03:08:53 +0000
 
@@ -200,7 +201,7 @@ texworks (0.5~svn1026-1) unstable; urgency=low
 
   * New Upstrean Release (rev 1026).
 
- -- Atsuhito KOHDA <kohda@debian.org>  Thu, 26 Sep 2012 16:48:05 +0900
+ -- Atsuhito KOHDA <kohda@debian.org>  Wed, 26 Sep 2012 16:48:05 +0900
 
 texworks (0.5~svn1007-1) unstable; urgency=low
 

--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Build-Depends: debhelper-compat (= 12),
  zlib1g-dev,
  libsynctex-dev (>= 2018.20180119.46378)
 Standards-Version: 4.2.1
-Homepage: http://www.tug.org/texworks/
+Homepage: https://www.tug.org/texworks/
 Vcs-Git: https://github.com/debian-tex/texworks.git
 Vcs-Browser: https://github.com/debian-tex/texworks
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/TeXworks/texworks/issues
+Bug-Submit: https://github.com/TeXworks/texworks/issues/new
+Repository: https://github.com/TeXworks/texworks.git
+Repository-Browse: https://github.com/TeXworks/texworks


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))
* Fix day-of-week for changelog entry 0.5~svn1026-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/texworks/6f2e327f-8899-4884-9386-f9543719988f.


## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/41/22941aa07171cae4d31782305b772ab442cd30.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3f/077154bb9a81e3c7be5fe0877705778965d037.debug
### Control files of package texworks: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.tug.org/texworks/-] {+https&#8203;://www.tug.org/texworks/+}
### Control files of package texworks-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-3f077154bb9a81e3c7be5fe0877705778965d037-] {+4122941aa07171cae4d31782305b772ab442cd30+}
### Control files of package texworks-scripting-lua: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.tug.org/texworks/-] {+https&#8203;://www.tug.org/texworks/+}

No differences were encountered between the control files of package \*\*texworks-scripting-lua-dbgsym\*\*
### Control files of package texworks-scripting-python: lines which differ (wdiff format)
* Homepage: [-http&#8203;://www.tug.org/texworks/-] {+https&#8203;://www.tug.org/texworks/+}

No differences were encountered between the control files of package \*\*texworks-scripting-python-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/6f2e327f-8899-4884-9386-f9543719988f/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/6f2e327f-8899-4884-9386-f9543719988f/diffoscope)).
