### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+texworks (0.6.6-3) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on cmake and libsynctex-dev.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Thu, 09 Sep 2021 12:49:58 -0000
+
 texworks (0.6.6-2) unstable; urgency=medium
 
   * The last "debuild -S" run unintentionally picked up the broken

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Uploaders: Norbert Preining <norbert@preining.info>,
   Hilmar Preusse <hille42@web.de>
 Build-Depends: debhelper-compat (= 12),
  pkg-config,
- cmake (>= 2.8.6),
+ cmake,
  libhunspell-dev,
  qtbase5-dev,
  qttools5-dev,
@@ -16,7 +16,7 @@ Build-Depends: debhelper-compat (= 12),
  liblua5.3-dev | liblua5.2-dev,
  python3-dev,
  zlib1g-dev,
- libsynctex-dev (>= 2018.20180119.46378)
+ libsynctex-dev
 Standards-Version: 4.2.1
 Homepage: https://www.tug.org/texworks/
 Vcs-Git: https://github.com/debian-tex/texworks.git


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/texworks/7caefbd7-7ad6-4dcf-9239-097b57f66040.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/68/5779554459d0dc0802f87c974f977380d16fae.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fc/061e38f7eba30ecdec5a1b489cb4058fe8a9f3.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fe/f72e7a412fd83c92a3d2acae7a9a7389671dfe.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/1e/c8385b85964c753704fc848f219c041a05886e.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3f/af495eb8c4f40b25e080fe5fd0e2625abfdee7.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/52/82f08ccbf70be6d2165955852b6c8e94254a78.debug

No differences were encountered between the control files of package \*\*texworks\*\*
### Control files of package texworks-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-1ec8385b85964c753704fc848f219c041a05886e-] {+685779554459d0dc0802f87c974f977380d16fae+}

No differences were encountered between the control files of package \*\*texworks-scripting-lua\*\*
### Control files of package texworks-scripting-lua-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-3faf495eb8c4f40b25e080fe5fd0e2625abfdee7-] {+fef72e7a412fd83c92a3d2acae7a9a7389671dfe+}

No differences were encountered between the control files of package \*\*texworks-scripting-python\*\*
### Control files of package texworks-scripting-python-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-5282f08ccbf70be6d2165955852b6c8e94254a78-] {+fc061e38f7eba30ecdec5a1b489cb4058fe8a9f3+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7caefbd7-7ad6-4dcf-9239-097b57f66040/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7caefbd7-7ad6-4dcf-9239-097b57f66040/diffoscope)).
