### PR TITLE
Update renamed lintian tag names in lintian overrides

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,13 @@
 texworks (0.6.7-2) UNRELEASED; urgency=medium
 
+  [ Hilmar Preusse ]
   * We are "Debian TeX Task Force".
   * Replace "http" by "https" in "texworks.appdata.xml".
   * Recommend fonts-urw-base35 instead of dummy package
     gsfonts. (Closes: #1020362)
+
+  [ Debian Janitor ]
+  * Update renamed lintian tag names in lintian overrides.
 
  -- Hilmar Preusse <hille42@web.de>  Tue, 20 Sep 2022 21:05:38 +0200
 

--- a/debian/source/lintian-overrides
+++ b/debian/source/lintian-overrides
@@ -1,2 +1,2 @@
-texworks source: debian-watch-does-not-check-gpg-signature
+texworks source: debian-watch-does-not-check-openpgp-signature
 texworks source: prefer-uscan-symlink


### PR DESCRIPTION

Update renamed lintian tag names in lintian overrides. ([renamed-tag](https://lintian.debian.org/tags/renamed-tag))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes). For more information, including instructions on how to disable these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts or close the merge proposal when all changes are applied through other means (e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at https://janitor.debian.net/lintian-fixes/pkg/texworks/61cbda9e-53b1-499e-9a4e-9d00d9311c84.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/95/479304e09901e5468af3839c2d9a360afb432f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/a7/c121068bfca5d56cc2d7b4150a580a15aeed7f.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/fa/17b396449eb1a645d25441effa71a0522d06ea.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/03/550f46bc3150633e472a1c900e341d371ff63c.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/58/c2b287c1ecfcd26b646b4f580abe791afa3fa0.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/61/5a90e390e5babe8cd311153eb1d8ec4ebe8f63.debug

No differences were encountered between the control files of package \*\*texworks\*\*
### Control files of package texworks-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-03550f46bc3150633e472a1c900e341d371ff63c-] {+fa17b396449eb1a645d25441effa71a0522d06ea+}

No differences were encountered between the control files of package \*\*texworks-scripting-lua\*\*
### Control files of package texworks-scripting-lua-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-58c2b287c1ecfcd26b646b4f580abe791afa3fa0-] {+95479304e09901e5468af3839c2d9a360afb432f+}

No differences were encountered between the control files of package \*\*texworks-scripting-python\*\*
### Control files of package texworks-scripting-python-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-615a90e390e5babe8cd311153eb1d8ec4ebe8f63-] {+a7c121068bfca5d56cc2d7b4150a580a15aeed7f+}


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/61cbda9e-53b1-499e-9a4e-9d00d9311c84/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/61cbda9e-53b1-499e-9a4e-9d00d9311c84/diffoscope)).
